### PR TITLE
Fix new_heads Events Emission on Block Forks

### DIFF
--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -143,8 +143,9 @@ func NotifyNewHeaders(ctx context.Context, finishStageBeforeSync uint64, finishS
 			heightSpan = 1024
 		}
 		notifyFrom = finishStageAfterSync - heightSpan
+		notifyFrom++
 	}
-	notifyFrom++
+	
 
 	var notifyTo = notifyFrom
 	var notifyToHash libcommon.Hash


### PR DESCRIPTION
new_heads events were not correctly emitted during block forks. This fix ensures accurate event generation and emission in fork scenarios.